### PR TITLE
Change required Elixir version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-This repository contains accompanying code for the [Elixir in Action](http://www.manning.com/juric/) book. To compile and run the code, you'll need Elixir 1.0.x and Erlang 17.0. A `git` client should also be installed and available somewhere in the execution path.
+This repository contains accompanying code for the [Elixir in Action](http://www.manning.com/juric/) book. To compile and run the code, you'll need Elixir 1.x and Erlang 17.0. A `git` client should also be installed and available somewhere in the execution path.
 
 The code in the master branch corresponds to the code in the printed edition. There are other branches in this repository, where code is adapted to run on subsequent Elixir versions.


### PR DESCRIPTION
If I am not mistaken (which I might be), [this commit](https://github.com/sasa1977/elixir-in-action/commit/05b6fb3a73db893727a5b9b43da4087af878f058) means that the code now requires Elixir `1.x` since you relaxed the version requirement.

This PR updates the README accordingly. :grin: 