### PR TITLE
Add note about the wrk tool

### DIFF
--- a/code_samples/ch11/todo_env/load_test.exs
+++ b/code_samples/ch11/todo_env/load_test.exs
@@ -6,4 +6,16 @@
 
 File.rm_rf("./persist")
 File.mkdir_p("./persist")
-:os.cmd('wrk -t4 -c100 -d120s --timeout 2000 -s wrk.lua "http://localhost:5454"') |> IO.puts
+
+
+# The load test uses wrk (https://github.com/wg/wrk): a modern HTTP benchmarking tool
+# capable of generating significant load when run on a single multi-core CPU.
+# 
+# Installation:
+# - OSX: Homebrew or build from source (https://github.com/wg/wrk/wiki/Installing-wrk-on-OSX)
+# - Linux: build from source (https://github.com/wg/wrk/wiki/Installing-Wrk-on-Linux)
+# - Windows: not available
+# 
+# This runs a benchmark for 120 seconds, using 4 threads, keeping 100 HTTP connections open,
+# timing out the request after 2 seconds, and evaluating wrk.lua to generate URLs.
+:os.cmd('wrk -t4 -c100 -d120s --timeout 2s -s wrk.lua "http://localhost:5454"') |> IO.puts

--- a/code_samples/ch11/todo_web/load_test.exs
+++ b/code_samples/ch11/todo_web/load_test.exs
@@ -6,4 +6,15 @@
 
 File.rm_rf("./persist")
 File.mkdir_p("./persist")
-:os.cmd('wrk -t4 -c100 -d120s --timeout 2000 -s wrk.lua "http://localhost:5454"') |> IO.puts
+
+# The load test uses wrk (https://github.com/wg/wrk): a modern HTTP benchmarking tool
+# capable of generating significant load when run on a single multi-core CPU.
+# 
+# Installation:
+# - OSX: Homebrew or build from source (https://github.com/wg/wrk/wiki/Installing-wrk-on-OSX)
+# - Linux: build from source (https://github.com/wg/wrk/wiki/Installing-Wrk-on-Linux)
+# - Windows: not available
+# 
+# This runs a benchmark for 120 seconds, using 4 threads, keeping 100 HTTP connections open,
+# timing out the request after 2 seconds, and evaluating wrk.lua to generate URLs.
+:os.cmd('wrk -t4 -c100 -d120s --timeout 2s -s wrk.lua "http://localhost:5454"') |> IO.puts

--- a/code_samples/ch11/todo_web_optimized/load_test.exs
+++ b/code_samples/ch11/todo_web_optimized/load_test.exs
@@ -7,7 +7,18 @@
 :ok = :mnesia.wait_for_tables([:todo_lists], 1000)
 {:atomic, :ok} = :mnesia.clear_table(:todo_lists)
 
-:os.cmd('wrk -t4 -c100 -d120s --timeout 2000 -s wrk.lua "http://localhost:5454"') |> IO.puts
+
+# The load test uses wrk (https://github.com/wg/wrk): a modern HTTP benchmarking tool
+# capable of generating significant load when run on a single multi-core CPU.
+# 
+# Installation:
+# - OSX: Homebrew or build from source (https://github.com/wg/wrk/wiki/Installing-wrk-on-OSX)
+# - Linux: build from source (https://github.com/wg/wrk/wiki/Installing-Wrk-on-Linux)
+# - Windows: not available
+# 
+# This runs a benchmark for 120 seconds, using 4 threads, keeping 100 HTTP connections open,
+# timing out the request after 2 seconds, and evaluating wrk.lua to generate URLs.
+:os.cmd('wrk -t4 -c100 -d120s --timeout 2s -s wrk.lua "http://localhost:5454"') |> IO.puts
 
 Application.stop(:mnesia)
 File.rm_rf("./Mnesia.nonode@nohost")

--- a/code_samples/ch12/todo_distributed/load_test.exs
+++ b/code_samples/ch12/todo_distributed/load_test.exs
@@ -6,4 +6,15 @@
 
 File.rm_rf("./persist")
 File.mkdir_p("./persist")
-:os.cmd('wrk -t4 -c100 -d120s --timeout 2000 -s wrk.lua "http://localhost:5454"') |> IO.puts
+
+# The load test uses wrk (https://github.com/wg/wrk): a modern HTTP benchmarking tool
+# capable of generating significant load when run on a single multi-core CPU.
+# 
+# Installation:
+# - OSX: Homebrew or build from source (https://github.com/wg/wrk/wiki/Installing-wrk-on-OSX)
+# - Linux: build from source (https://github.com/wg/wrk/wiki/Installing-Wrk-on-Linux)
+# - Windows: not available
+# 
+# This runs a benchmark for 120 seconds, using 4 threads, keeping 100 HTTP connections open,
+# timing out the request after 2 seconds, and evaluating wrk.lua to generate URLs.
+:os.cmd('wrk -t4 -c100 -d120s --timeout 2s -s wrk.lua "http://localhost:5454"') |> IO.puts

--- a/code_samples/ch13/todo_release/load_test.exs
+++ b/code_samples/ch13/todo_release/load_test.exs
@@ -6,4 +6,15 @@
 
 File.rm_rf("./persist")
 File.mkdir_p("./persist")
-:os.cmd('wrk -t4 -c100 -d120s --timeout 2000 -s wrk.lua "http://localhost:5454"') |> IO.puts
+
+# The load test uses wrk (https://github.com/wg/wrk): a modern HTTP benchmarking tool
+# capable of generating significant load when run on a single multi-core CPU.
+# 
+# Installation:
+# - OSX: Homebrew or build from source (https://github.com/wg/wrk/wiki/Installing-wrk-on-OSX)
+# - Linux: build from source (https://github.com/wg/wrk/wiki/Installing-Wrk-on-Linux)
+# - Windows: not available
+# 
+# This runs a benchmark for 120 seconds, using 4 threads, keeping 100 HTTP connections open,
+# timing out the request after 2 seconds, and evaluating wrk.lua to generate URLs.
+:os.cmd('wrk -t4 -c100 -d120s --timeout 2s -s wrk.lua "http://localhost:5454"') |> IO.puts

--- a/code_samples/ch13/todo_runtime/load_test.exs
+++ b/code_samples/ch13/todo_runtime/load_test.exs
@@ -6,4 +6,15 @@
 
 File.rm_rf("./persist")
 File.mkdir_p("./persist")
-:os.cmd('wrk -t4 -c100 -d120s --timeout 2000 -s wrk.lua "http://localhost:5454"') |> IO.puts
+
+# The load test uses wrk (https://github.com/wg/wrk): a modern HTTP benchmarking tool
+# capable of generating significant load when run on a single multi-core CPU.
+# 
+# Installation:
+# - OSX: Homebrew or build from source (https://github.com/wg/wrk/wiki/Installing-wrk-on-OSX)
+# - Linux: build from source (https://github.com/wg/wrk/wiki/Installing-Wrk-on-Linux)
+# - Windows: not available
+# 
+# This runs a benchmark for 120 seconds, using 4 threads, keeping 100 HTTP connections open,
+# timing out the request after 2 seconds, and evaluating wrk.lua to generate URLs.
+:os.cmd('wrk -t4 -c100 -d120s --timeout 2s -s wrk.lua "http://localhost:5454"') |> IO.puts


### PR DESCRIPTION
- I've added a note about the wrk tool,
- I also added the direct link to installation instructions, since it has to be built from source on Linux. wrk will not work on Windows, based on [this comment](https://github.com/wg/wrk/issues/49#issuecomment-26962860),
- seems that the value 2000 for the timeout parameter is a mistake, since the default unit is seconds and wrk will [try to allocate lots of memory](https://github.com/wg/wrk/blob/master/src/wrk.c#L91) to calculate statistics; changed it to 2s even though it's the default (although the default in code is expressed in miliseconds)