### PR TITLE
Switched to :rand to reflect the deprecation of :random in Erlang

### DIFF
--- a/code_samples/ch05/stateful_database_server.ex
+++ b/code_samples/ch05/stateful_database_server.ex
@@ -1,7 +1,7 @@
 defmodule DatabaseServer do
   def start do
     spawn(fn ->
-      connection = :random.uniform(1000)
+      connection = :rand.uniform(1000)
       loop(connection)
     end)
   end


### PR DESCRIPTION
Erlang appears to have deprecated :random and this was causing a warning when compiling the stateful database server project. Switching the statement to use :rand makes things lovely once again. (No other instances of :random were found in the book's code samples.)