### PR TITLE
update database store operation from cast to call

### DIFF
--- a/code_samples/ch11/todo_poolboy/lib/todo/database_worker.ex
+++ b/code_samples/ch11/todo_poolboy/lib/todo/database_worker.ex
@@ -6,7 +6,7 @@ defmodule Todo.DatabaseWorker do
   end
 
   def store(pid, key, data) do
-    GenServer.cast(pid, {:store, key, data})
+    GenServer.call(pid, {:store, key, data})
   end
 
   def get(pid, key) do
@@ -19,12 +19,12 @@ defmodule Todo.DatabaseWorker do
   end
 
   @impl GenServer
-  def handle_cast({:store, key, data}, db_folder) do
+  def handle_call({:store, key, data}, _, db_folder) do
     db_folder
     |> file_name(key)
     |> File.write!(:erlang.term_to_binary(data))
 
-    {:noreply, db_folder}
+    {:reply, :ok, db_folder}
   end
 
   @impl GenServer


### PR DESCRIPTION
Due to the poolboy implementation the database module lost the feature of all requests of the same list being handled by the same worker.

Because of it, the worker store operation must be updated from cast to call, otherwise the Todo.Server could issue a new write request on while the previous write request is not complete.

This could lead multiple workers to try access the same file at the same time, leading to race condition errors.