### PR TITLE
remove tool-versions file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.tool-versions

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,0 @@
-erlang 21.0.9
-elixir 1.7.3-otp-21


### PR DESCRIPTION
Elixir noob here,

After release of elixir 1.14, i've made the choice to install elixir with asdf instead of dnf.
But after doing this, i've got trouble to understand why a vscode warning was saying to me I should install elixir 1.7.
It took me 2 hours to just find out this file is making my current trouble.

In order to not share this bad (but inherent to noob usage like me) for newcomers to this language, removing this file could maybe save few hours of frustration for other noob developers.